### PR TITLE
ci: bump macos-10.15 to macos-12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -175,13 +175,13 @@ jobs:
           path: ${{ env.APP_NAME }}.*.node
           if-no-files-found: error
   build-freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     name: Build FreeBSD
     steps:
       - uses: actions/checkout@v3
       - name: Build
         id: build
-        uses: vmactions/freebsd-vm@v0.1.6
+        uses: vmactions/freebsd-vm@v0.2.0
         env:
           DEBUG: napi:*
           RUSTUP_HOME: /usr/local/rustup


### PR DESCRIPTION
## Motivation

In this job I noticed some [error messages](https://github.com/liby/hexo-util-rs/actions/runs/2712796910):
> [CI: .github#L1](https://github.com/liby/hexo-util-rs/pull/20/files#annotation_4083141746)
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583
>
> [Build FreeBSD](https://github.com/liby/hexo-util-rs/runs/7452665499?check_suite_focus=true)
This is a scheduled macOS-10.15 brownout. The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583

## Changes

Updated the `runs-on` to `macos-12` and bumped `vmactions/freebsd-vm` to `0.2.0`(`macos-12` require).