### PR TITLE
ci: use --immutable instead of --frozen-lockfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           key: npm-cache-lint-node@16
 
       - name: Install dependencies
-        run: yarn install --immutable --registry https://registry.npmjs.org --network-timeout 300000
+        run: yarn install --immutable --network-timeout 300000
 
       - name: ESLint
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,8 @@ jobs:
           path: node_modules
           key: npm-cache-lint-node@16
 
-      - name: 'Install dependencies'
-        run: yarn install --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
+      - name: Install dependencies
+        run: yarn install --immutable --registry https://registry.npmjs.org --network-timeout 300000
 
       - name: ESLint
         run: yarn lint

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
 nodeLinker: node-modules
 
+npmAuditRegistry: "https://registry.npmjs.org"
+
 yarnPath: .yarn/releases/yarn-3.3.0.cjs
+


### PR DESCRIPTION
## Motivation

- `--registry` and `--frozen-lockfile` options have been deprecated. They will be removed in future release.

## Changes

- The `--registry` option is deprecated; [prefer setting `npmRegistryServer` in *.yarnrc.yml* file](https://yarnpkg.com/configuration/yarnrc#npmAuditRegistry)
- The  `--frozen-lockfile` option is deprecated; [use `--immutable` instead](https://yarnpkg.com/getting-started/migration#step-by-step:~:text=%2C%20and%20renamed-,%2D%2Dfrozen%2Dlockfile,-into)