### PR TITLE
ci: use `dtolnay/rust-toolchain` instead of `actions-rs/toolchain`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,9 @@ jobs:
           check-latest: true
 
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
+          components: clippy, rustfmt
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
## Motivation

The [actions-rs/toolchain](https://github.com/actions-rs/toolchain) project has been unmaintained for almost 2 years. 

Issues such as https://github.com/actions-rs/toolchain/issues/221 and https://github.com/actions-rs/toolchain/issues/219 are pending.

Use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead.

