### PR TITLE
fix: fix husky init

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prepublishOnly": "napi prepublish -t npm",
     "test": "ava",
     "version": "napi version",
-    "prepare": "husky"
+    "postinstall": "husky"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
@@ -64,7 +64,7 @@
     "@taplo/cli": "^0.7.0",
     "ava": "^6.1.3",
     "chalk": "^5.3.0",
-    "husky": "^9.0.11",
+    "husky": "^9.1.7",
     "lint-staged": "^15.2.7",
     "npm-run-all2": "^7.0.0",
     "oxlint": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,7 +71,7 @@ __metadata:
     "@taplo/cli": "npm:^0.7.0"
     ava: "npm:^6.1.3"
     chalk: "npm:^5.3.0"
-    husky: "npm:^9.0.11"
+    husky: "npm:^9.1.7"
     lint-staged: "npm:^15.2.7"
     npm-run-all2: "npm:^7.0.0"
     oxlint: "npm:^0.15.0"
@@ -1222,12 +1222,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^9.0.11":
-  version: 9.0.11
-  resolution: "husky@npm:9.0.11"
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
   bin:
-    husky: bin.mjs
-  checksum: 10c0/2c787dcf74a837fc9a4fea7da907509d4bd9a289f4ea10ecc9d86279e4d4542b0f5f6443a619bccae19e265f2677172cc2b86aae5c932a35a330cc227d914605
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to update the `husky` dependency and modify the script configuration.

Because yarn doesn't support prepare.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/b9cd7637-4424-463a-a076-f358e561a7b9" />


Dependency updates and script configuration changes:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R58): Changed the `prepare` script to `postinstall` for `husky`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L67-R67): Updated the `husky` dependency version from `^9.0.11` to `^9.1.7`.