### PR TITLE
fix typo in GH Actions - eslint -> oxlint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: ESLint
+      - name: Oxlint
         run: yarn lint
 
       - name: Cargo fmt


### PR DESCRIPTION
👋 The project uses Oxlint for linting, but the CI step is named `Eslint` 😄 

It confused me a bit, so shipping a fix ❤️ 