### PR TITLE
fix: remove un-needed extern crate from `build.rs` 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate napi_build;
-
 fn main() {
   napi_build::setup();
 }


### PR DESCRIPTION
Clippy was telling me that extern crate isn't needed, as [build-dependencies ](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies)are already set in cargo toml https://github.com/napi-rs/package-template/blob/main/Cargo.toml#L17