### PR TITLE
docs: improve publish instructions and add warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Install this test package
 
-```
+```bash
 yarn add @napi-rs/package-template
 ```
 
@@ -76,10 +76,12 @@ In `Settings -> Secrets`, add **NPM_TOKEN** into it.
 
 When you want to release the package:
 
-```
+```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
 
-git push
+git push --tags
 ```
 
 GitHub actions will do the rest job for you.
+
+> WARN: Don't run `npm publish` manually.


### PR DESCRIPTION
- Add bash syntax highlighting for code blocks
- Include --tags flag for git push to ensure tags are pushed
- Add warning note about not running npm publish manually

🤖 Generated with [Claude Code](https://claude.ai/code)