### PR TITLE
Fix webassembly compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ napi-build = "2"
 
 [profile.release]
 lto   = true
-strip = "symbols"
+strip = "debuginfo"


### PR DESCRIPTION
Using this template for webassembly is challenging due to this option being enabled: `symbols` leads to a freeze (firefox popOS).

I was able to track down the origin by comparing it to the working example of https://github.com/napi-rs/napi-rs/tree/main/examples/napi.

It may be desirable to downgrade it only when building for web assembly, but in the meantime this strictly leads to a better default for webassembly curious, which I imagine latest blog post https://napi.rs/blog/announce-v3 may bring.